### PR TITLE
feat: ゲストログイン機能

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,9 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    user = User.guest
+
+    sign_in user
+
+    redirect_to root_path, notice: t('devise.sessions.guest_welcome')
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,8 +2,13 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     user = User.guest
 
+    unless user&.persisted?
+      redirect_to root_path, alert: t('devise.sessions.guest.failure')
+      return
+    end
+
     sign_in user
 
-    redirect_to root_path, notice: t('devise.sessions.guest_welcome')
+    redirect_to root_path, notice: t('devise.sessions.guest.sign_in')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,13 @@ class User < ApplicationRecord
       user.nickname = auth.info.nickname
     end
   end
+
+  def self.guest
+    find_or_create_by!(email: 'guest@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.nickname = 'ゲスト'
+      user.provider = 'guest'
+      user.uid = SecureRandom.uuid
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
       user.password = SecureRandom.urlsafe_base64
       user.nickname = 'ゲスト'
       user.provider = 'guest'
-      user.uid = SecureRandom.uuid
+      user.uid = 'guest'
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   end
 
   def self.guest
-    find_or_create_by!(email: 'guest@example.com') do |user|
+    find_or_create_by(email: 'guest@example.com') do |user|
       user.password = SecureRandom.urlsafe_base64
       user.nickname = 'ゲスト'
       user.provider = 'guest'

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,7 +16,7 @@
       </p>
       
       <div class="flex flex-col sm:flex-row gap-5 justify-center">
-        <%= button_to 'users_guest_sign_in_path', method: :post, data: { turbo: false }, class: "flex items-center justify-center w-full sm:w-auto px-10 py-5 bg-green-600 hover:bg-green-500 text-white text-lg font-bold rounded-xl shadow-lg shadow-green-900/40 transition transform hover:-translate-y-1 border border-green-500 ring-4 ring-green-900/20" do %>
+        <%= button_to users_guest_sign_in_path, method: :post, data: { turbo: false }, class: "flex items-center justify-center w-full sm:w-auto px-10 py-5 bg-green-600 hover:bg-green-500 text-white text-lg font-bold rounded-xl shadow-lg shadow-green-900/40 transition transform hover:-translate-y-1 border border-green-500 ring-4 ring-green-900/20" do %>
           🚀 ゲストとして試す
         <% end %>
 
@@ -143,7 +143,7 @@
       </p>
       
       <div class="flex flex-col sm:flex-row gap-5 justify-center">
-         <%= button_to 'users_guest_sign_in_path', method: :post, data: { turbo: false }, class: "flex items-center justify-center w-full sm:w-auto px-12 py-5 bg-green-600 hover:bg-green-500 text-white text-lg font-bold rounded-xl shadow-xl shadow-green-900/40 transition transform hover:-translate-y-1 border border-green-500 ring-4 ring-green-900/20" do %>
+         <%= button_to users_guest_sign_in_path, method: :post, data: { turbo: false }, class: "flex items-center justify-center w-full sm:w-auto px-12 py-5 bg-green-600 hover:bg-green-500 text-white text-lg font-bold rounded-xl shadow-xl shadow-green-900/40 transition transform hover:-translate-y-1 border border-green-500 ring-4 ring-green-900/20" do %>
           🚀 ゲストとして試す
         <% end %>
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -18,7 +18,7 @@
         </div>
 
       <% else %>
-        <%= button_to 'users_guest_sign_in_path', method: :post, data: { turbo: false }, class: "text-sm bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded transition font-bold shadow-lg shadow-green-900/20" do %>
+        <%= button_to users_guest_sign_in_path, method: :post, data: { turbo: false }, class: "text-sm bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded transition font-bold shadow-lg shadow-green-900/20" do %>
           ゲストログイン
         <% end %>
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -3,3 +3,5 @@ ja:
     omniauth_callbacks:
       failure:
         email_missing: "GitHubアカウントからメールアドレスを取得できませんでした。"
+    sessions:
+      guest_welcome: "ゲストユーザーとしてログインしました。"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -4,4 +4,6 @@ ja:
       failure:
         email_missing: "GitHubアカウントからメールアドレスを取得できませんでした。"
     sessions:
-      guest_welcome: "ゲストユーザーとしてログインしました。"
+      guest:
+        sign_in: "ゲストユーザーとしてログインしました。"
+        failure: "ゲストユーザーの作成に失敗しました。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
+
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in', as: :users_guest_sign_in
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       email { 'guest@example.com' }
       nickname { 'ゲスト' }
       provider { 'guest' }
-      uid { 'guest_uid_for_demo' }
+      uid { 'guest' }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,12 @@ FactoryBot.define do
       sequence(:nickname) { |n| "user_handle_#{n}" }
       sequence(:uid) { |n| "uid#{n}" }
     end
+
+    trait :guest do
+      email { 'guest@example.com' }
+      nickname { 'ゲスト' }
+      provider { 'guest' }
+      uid { 'guest_uid_for_demo' }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '.guest' do
+    context 'ゲストユーザーがDBに存在しない場合' do
+      it '新規ユーザーを作成し、ゲスト用の属性が設定されること' do
+        expect { described_class.guest }.to change(described_class, :count).by(1)
+
+        guest_user = described_class.guest
+        expect(guest_user.email).to eq('guest@example.com')
+        expect(guest_user.nickname).to eq('ゲスト')
+        expect(guest_user.provider).to eq('guest')
+      end
+    end
+
+    context 'ゲストユーザーがDBに存在する場合' do
+      let!(:existing_guest) { create(:user, :guest) }
+
+      it '新規ユーザーを作成せず、既存のユーザーを返すこと' do
+        expect { described_class.guest }.not_to change(described_class, :count)
+
+        expect(described_class.guest).to eq(existing_guest)
+      end
+    end
+  end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -5,28 +5,59 @@ RSpec.describe 'Sessions', type: :request do
 
   include Devise::Test::IntegrationHelpers
 
-  context 'ログイン済みの場合' do
-    before do
-      sign_in user
+  describe 'ログアウト' do
+    context 'ログイン済みの場合' do
+      before do
+        sign_in user
+      end
+
+      it 'DELETEリクエストによりログアウトが成功し、ルートパスにリダイレクトされること' do
+        delete destroy_user_session_path
+
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(root_path)
+
+        follow_redirect!
+        expect(response.body).to include('ログアウトしました。')
+      end
     end
 
-    it 'DELETEリクエストによりログアウトが成功し、ルートパスにリダイレクトされること' do
-      delete destroy_user_session_path
+    context '未ログインの場合' do
+      it 'ログアウト処理を実行してもエラーにならないこと' do
+        delete destroy_user_session_path
 
-      expect(response).to have_http_status(:see_other)
-      expect(response).to redirect_to(root_path)
-
-      follow_redirect!
-      expect(response.body).to include('ログアウトしました。')
+        follow_redirect!
+        expect(response.body).to include('既にログアウト済みです。')
+      end
     end
   end
 
-  context '未ログインの場合' do
-    it 'ログアウト処理を実行してもエラーにならないこと' do
-      delete destroy_user_session_path
+  describe 'ゲストログイン' do
+    context 'ユーザーが未登録の場合' do
+      it 'ゲストログインが成功し、フラッシュメッセージが表示されること' do
+        expect { post users_guest_sign_in_path }.to change(User, :count).by(1)
+        follow_redirect!
+        expect(response.body).to include(I18n.t('devise.sessions.guest_welcome'))
+        expect(User.last.email).to eq 'guest@example.com'
+        expect(User.last.nickname).to eq 'ゲスト'
+      end
+    end
 
-      follow_redirect!
-      expect(response.body).to include('既にログアウト済みです。')
+    context 'ゲストユーザーが既に存在する場合' do
+      let(:existing_guest) { create(:user, :guest) }
+      let(:initial_user_count) { User.count }
+
+      before do
+        delete destroy_user_session_path
+        post users_guest_sign_in_path
+        follow_redirect!
+      end
+
+      it '新規ユーザーを作成せず、既存のユーザーでログインすること' do
+        expect(User.count).to eq initial_user_count
+
+        expect(response.body).to include(I18n.t('devise.sessions.guest_welcome'))
+      end
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -44,17 +44,15 @@ RSpec.describe 'Sessions', type: :request do
     end
 
     context 'ゲストユーザーが既に存在する場合' do
-      let(:existing_guest) { create(:user, :guest) }
-      let(:initial_user_count) { User.count }
-
       before do
-        delete destroy_user_session_path
-        post users_guest_sign_in_path
-        follow_redirect!
+        create(:user, :guest)
       end
 
       it '新規ユーザーを作成せず、既存のユーザーでログインすること' do
-        expect(User.count).to eq initial_user_count
+        initial_count = User.count
+        post users_guest_sign_in_path
+        expect(User.count).to eq initial_count
+        follow_redirect!
 
         expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
       end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Sessions', type: :request do
       it 'ゲストログインが成功し、フラッシュメッセージが表示されること' do
         expect { post users_guest_sign_in_path }.to change(User, :count).by(1)
         follow_redirect!
-        expect(response.body).to include(I18n.t('devise.sessions.guest_welcome'))
+        expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
         expect(User.last.email).to eq 'guest@example.com'
         expect(User.last.nickname).to eq 'ゲスト'
       end
@@ -56,7 +56,7 @@ RSpec.describe 'Sessions', type: :request do
       it '新規ユーザーを作成せず、既存のユーザーでログインすること' do
         expect(User.count).to eq initial_user_count
 
-        expect(response.body).to include(I18n.t('devise.sessions.guest_welcome'))
+        expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
       end
     end
   end


### PR DESCRIPTION
## 概要

Deviseのセッション機能を利用し、GitHub認証や新規登録の手順を踏まずに、**ワンクリックでアプリの機能を試用できる「ゲストログイン機能」**を実装しました。

これにより、面接官はログインの手間なく即座にアプリのコア機能にアクセスできるようになり、デモ体験が向上します。

## 関連 Issue

#9 

## 対応内容

 ### 認証・ロジック層の変更
- User Model: self.guest メソッドを追加。email: 'guest@example.com' のユーザーが常に1人だけ存在するように find_or_create_by! ロジックを実装
- Controller: Users::SessionsController に guest_sign_in アクションを追加し、User.guest の呼び出しとセッション確立（sign_in）を定義
- ルーティング: devise_scope :user ブロック内に /users/guest_sign_in ルートを POST メソッドで定義
- i18n対応: 成功時のメッセージを ja.yml に追加

### フロントエンド

- ヘッダーおよびLPのゲストログインボタンのパスを修正
- ユーザー名表示は current_user.nickname を利用

## 動作確認
- [x] 新規作成の検証: 初回ログイン時に、ユーザー数が1増え、email: 'guest@example.com' のユーザーが作成されること
- [x] 検索の検証: 2回目以降のログインでは、ユーザー数が増加せず、既存のゲストユーザーが利用されること
- [x] ログイン: LPのボタンからログインが成功し、ヘッダーに ゲスト と表示されること
- [x] ログアウト: ヘッダーのログアウトボタンで正常にセッションが破棄され、LPに戻ること

## 備考
💡 ポートフォリオとしての意図
利便性: 採用担当者向けに、最も低い摩擦（Friction）でデモを体験してもらうためのUX設計です

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guest sign-in: use a guest account to sign in without full registration; buttons added to header and home page.
* **Localization**
  * Japanese messages for guest sign-in success and failure.
* **Tests**
  * Added specs covering guest account creation, reuse, and guest sign-in/logout flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->