### PR TITLE
feat: 日報作成機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  protected
+
+  def authenticate_user!(_options = {})
+    return if user_signed_in?
+
+    flash[:alert] = t('common.login_required')
+
+    redirect_to root_path and return
+  end
 end

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -12,7 +12,7 @@ class DailyReportsController < ApplicationController
     if @daily_report.save
       redirect_to daily_reports_path, notice: t('.success')
     else
-      render :new
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -1,0 +1,22 @@
+class DailyReportsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @daily_report = current_user.daily_reports.build
+  end
+
+  def create
+    @daily_report = current_user.daily_reports.build(daily_report_params)
+    if @daily_report.save
+      redirect_to daily_reports_path, notice: t('.success')
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def daily_report_params
+    params.require(:daily_report).permit(:date, :content)
+  end
+end

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -4,7 +4,7 @@ class DailyReportsController < ApplicationController
   def index; end
 
   def new
-    @daily_report = current_user.daily_reports.build
+    @daily_report = current_user.daily_reports.build(date: Date.current)
   end
 
   def create

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -1,6 +1,8 @@
 class DailyReportsController < ApplicationController
   before_action :authenticate_user!
 
+  def index; end
+
   def new
     @daily_report = current_user.daily_reports.build
   end

--- a/app/models/daily_report.rb
+++ b/app/models/daily_report.rb
@@ -3,6 +3,6 @@ class DailyReport < ApplicationRecord
 
   validates :date, presence: true, comparison: { less_than_or_equal_to: lambda {
     Date.current
-  } }, uniqueness: { scope: :user_id }
+  }, allow_blank: true }, uniqueness: { scope: :user_id }
   validates :content, presence: true
 end

--- a/app/models/daily_report.rb
+++ b/app/models/daily_report.rb
@@ -1,6 +1,8 @@
 class DailyReport < ApplicationRecord
   belongs_to :user
 
-  validates :date, presence: true, comparison: { less_than_or_equal_to: Date.current }, uniqueness: { scope: :user_id }
+  validates :date, presence: true, comparison: { less_than_or_equal_to: lambda {
+    Date.current
+  } }, uniqueness: { scope: :user_id }
   validates :content, presence: true
 end

--- a/app/models/daily_report.rb
+++ b/app/models/daily_report.rb
@@ -1,0 +1,6 @@
+class DailyReport < ApplicationRecord
+  belongs_to :user
+
+  validates :date, presence: true, comparison: { less_than_or_equal_to: Date.current }, uniqueness: { scope: :user_id }
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]
 
+  has_many :daily_reports, dependent: :destroy
+
   def self.from_omniauth(auth)
     return nil if auth.info.email.blank?
 

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -1,0 +1,30 @@
+<%= form_with model: daily_report, local: true, data: { turbo: false }, class: "space-y-6" do |f| %>
+  
+  <%= render 'shared/error_messages', model: daily_report, subject: daily_report.new_record? ? '日報の作成' : '日報の更新' %>
+
+  <div>
+    <%= f.label :date, "日付", class: "block text-sm font-medium text-gray-400 mb-1" %>
+    
+    <% error_class = f.object.errors[:date].present? ? 'border-red-500' : 'border-gray-700' %>
+    
+    <%= f.date_field :date, value: Date.today, 
+      class: "w-full p-3 bg-gray-800 #{error_class} rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500" %>
+
+    <%= render 'shared/field_error', f: f, field: :date %>
+  </div>
+
+  <div>
+    <%= f.label :content, "活動内容・振り返り (Markdown対応)", class: "block text-sm font-medium text-gray-400 mb-1" %>
+    
+    <% error_class = f.object.errors[:content].present? ? 'border-red-500' : 'border-gray-700' %>
+    
+    <%= f.text_area :content, rows: 15, required: true, 
+      class: "w-full p-3 bg-gray-800 #{error_class} rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500 resize-y" %>
+
+    <%= render 'shared/field_error', f: f, field: :content %>
+  </div>
+
+  <div class="flex justify-end pt-4 border-t border-gray-700">
+    <%= f.submit "日報を保存", data: { turbo_submits: true }, class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg shadow-indigo-900/30" %>
+  </div>
+<% end %>

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: daily_report, local: true, data: { turbo: false }, class: "space-y-6" do |f| %>
   
-  <%= render 'shared/error_messages', model: daily_report, subject: daily_report.new_record? ? '日報の作成' : '日報の更新' %>
+  <%= render 'shared/error_messages', model: daily_report, subject: '日報の保存' %>
 
   <div>
     <%= f.label :date, "日付", class: "block text-sm font-medium text-gray-400 mb-1" %>

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -7,7 +7,7 @@
     
     <% error_class = f.object.errors[:date].present? ? 'border-red-500' : 'border-gray-700' %>
     
-    <%= f.date_field :date, value: Date.current, 
+    <%= f.date_field :date,
       class: "w-full p-3 bg-gray-800 #{error_class} rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500" %>
 
     <%= render 'shared/field_error', f: f, field: :date %>

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -7,7 +7,7 @@
     
     <% error_class = f.object.errors[:date].present? ? 'border-red-500' : 'border-gray-700' %>
     
-    <%= f.date_field :date, value: Date.today, 
+    <%= f.date_field :date, value: Date.current, 
       class: "w-full p-3 bg-gray-800 #{error_class} rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500" %>
 
     <%= render 'shared/field_error', f: f, field: :date %>

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -25,6 +25,6 @@
   </div>
 
   <div class="flex justify-end pt-4 border-t border-gray-700">
-    <%= f.submit "日報を保存", data: { turbo_submits: true }, class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg shadow-indigo-900/30" %>
+    <%= f.submit "日報を保存", class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg shadow-indigo-900/30" %>
   </div>
 <% end %>

--- a/app/views/daily_reports/index.html.erb
+++ b/app/views/daily_reports/index.html.erb
@@ -1,0 +1,13 @@
+<div class="container mx-auto px-4 py-8 max-w-4xl">
+  <h1 class="text-3xl font-bold text-white mb-6 border-b border-gray-700 pb-3">
+    🗓️ 日報カレンダー（工事中）
+  </h1>
+  
+  <p class="text-gray-400 mb-8">
+    日報一覧とカレンダー機能は、次のタスクで実装します。
+    <span class="text-indigo-400">（日報が保存されると、ここに移動します！）</span>
+  </p>
+  
+  <div class="bg-gray-800 p-6 rounded-lg min-h-[400px]">
+    </div>
+</div>

--- a/app/views/daily_reports/new.html.erb
+++ b/app/views/daily_reports/new.html.erb
@@ -1,0 +1,7 @@
+<div class="container mx-auto px-4 py-8 max-w-2xl bg-gray-900 rounded-lg shadow-xl">
+  <h1 class="text-3xl font-bold text-white mb-6 border-b border-gray-700 pb-3">
+    新しい日報を作成
+  </h1>
+  
+  <%= render 'form', daily_report: @daily_report %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
 
     <nav class="flex items-center gap-4">
       <% if user_signed_in? %>
-        <%= link_to "＋ 日報を書く", "#", class: "hidden md:inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
+        <%= link_to "＋ 日報を書く", new_daily_report_path, class: "hidden md:inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
 
         <div class="flex items-center gap-4 border-l border-gray-700 pl-4">
           <span class="text-sm text-indigo-400 font-medium hidden sm:block">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% subject_text = local_assigns.fetch(:subject, "処理") %>
+
+<% if model.errors.any? %>
+  <div class="bg-red-900/40 border border-red-800 text-red-300 p-4 rounded-lg mb-6">
+    <p class="font-bold mb-2"><%= subject_text %>に失敗しました。</p>
+    <ul class="list-disc list-inside text-sm space-y-1">
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_field_error.html.erb
+++ b/app/views/shared/_field_error.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.errors[field].present? %>
+  <p class="text-red-400 text-sm mt-1">
+    <%= f.object.errors.full_messages_for(field).join(", ") %>
+  </p>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,4 +20,4 @@ ja:
   daily_reports:
     create:
       success: "日報を作成しました"
-      failure: "日報の作成に失敗しました"
+      failure: "日報の保存に失敗しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,20 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      daily_report: 日報
     attributes:
       user:
         email: メールアドレス
+      daily_report:
+        date: 日付
+        content: 内容
+    errors:
+      models:
+        daily_report:
+          attributes:
+            date:
+              less_than_or_equal_to: "は、未来の日付として登録できません"
+  daily_reports:
+    create:
+      success: "日報を作成しました"
+      failure: "日報の作成に失敗しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,8 @@ ja:
           attributes:
             date:
               less_than_or_equal_to: "は、未来の日付として登録できません"
+  common:
+    login_required: "ログインが必要です。"
   daily_reports:
     create:
       success: "日報を作成しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in', as: :users_guest_sign_in
   end
+
+  resources :daily_reports
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20251202133821_create_daily_reports.rb
+++ b/db/migrate/20251202133821_create_daily_reports.rb
@@ -1,0 +1,12 @@
+class CreateDailyReports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :daily_reports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :date, null: false
+      t.text :content, null: false
+      t.timestamps
+    end
+
+    add_index :daily_reports, [:user_id, :date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_29_134425) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_02_133821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "daily_reports", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "date", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "date"], name: "index_daily_reports_on_user_id_and_date", unique: true
+    t.index ["user_id"], name: "index_daily_reports_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -30,4 +40,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_29_134425) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "daily_reports", "users"
 end

--- a/spec/factories/daily_reports.rb
+++ b/spec/factories/daily_reports.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :daily_report do
+    association :user
+    sequence(:date) { |n| n.days.ago.to_date }
+    content { 'test' }
+  end
+end

--- a/spec/models/daily_report_spec.rb
+++ b/spec/models/daily_report_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe DailyReport, type: :model do
+  let(:user) { create(:user) }
+  let(:valid_report) { build(:daily_report, user: user, date: Date.current, content: 'test') }
+
+  describe 'Associations' do
+    it { is_expected.to belong_to(:user) }
+
+    it 'userがnilの場合は無効であること' do
+      report = build(:daily_report, user: nil)
+      expect(report).to be_invalid
+    end
+  end
+
+  describe 'Validations' do
+    it 'contentがない場合は無効であること' do
+      report = build(:daily_report, content: nil)
+      expect(report).to be_invalid
+    end
+
+    context '日付の重複チェック' do
+      before { valid_report.save! }
+
+      it '同じuserが同日に作成した場合は無効であること' do
+        duplicate_report = build(:daily_report, user: user, date: Date.current)
+        expect(duplicate_report).to be_invalid
+        expect(duplicate_report.errors[:date]).to include('はすでに存在します')
+      end
+
+      it '異なるuserであれば同日に作成可能であること' do
+        other_user = create(:user)
+        expect(build(:daily_report, user: other_user, date: Date.current)).to be_valid
+      end
+    end
+
+    it '未来の日付の場合は無効であり、エラーメッセージを含むこと' do
+      future_report = build(:daily_report, user: user, date: Date.tomorrow)
+      expect(future_report).to be_invalid
+      expect(future_report.errors[:date]).to include(
+        I18n.t('activerecord.errors.models.daily_report.attributes.date.less_than_or_equal_to')
+      )
+    end
+  end
+end

--- a/spec/requests/daily_report_spec.rb
+++ b/spec/requests/daily_report_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'DailyReports', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  let(:valid_params) do
+    { daily_report: attributes_for(:daily_report, date: Date.current) }
+  end
+  let(:invalid_params) do
+    { daily_report: attributes_for(:daily_report, content: nil) }
+  end
+
+  describe 'GET #new' do
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      it '正常にレスポンスを返し、新しい日報オブジェクトを保持すること' do
+        get new_daily_report_path
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('新しい日報を作成')
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'トップページにリダイレクトされること' do
+        get new_daily_report_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      context 'パラメータが有効な場合' do
+        it '日報がDBに保存され、カレンダーページにリダイレクトすること' do
+          expect do
+            post daily_reports_path, params: valid_params
+          end.to change(DailyReport, :count).by(1)
+
+          expect(response).to redirect_to(daily_reports_path)
+        end
+      end
+
+      context 'パラメータが無効な場合' do
+        it '日報がDBに保存されず、フォームが再表示されること' do
+          expect do
+            post daily_reports_path, params: invalid_params
+          end.not_to change(DailyReport, :count)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include(I18n.t('daily_reports.create.failure'))
+        end
+      end
+    end
+
+    context '未ログインの場合' do
+      it '日報が保存されず、トップページにリダイレクトされること' do
+        expect do
+          post daily_reports_path, params: valid_params
+        end.not_to change(DailyReport, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

日報（DailyReport）モデルの構造定義と、新規作成機能（#new および #create）を実装しました。

## 関連 Issue

- #10

## 対応内容

### データベース・モデル層
- DBスキーマ: DailyReport テーブルを作成
- データ整合性: user_id と date の複合ユニークインデックスを追加し、「同一ユーザーの同日重複登録」をDBレベルで防止
- バリデーション: dateとcontentを入力必須にし、`validates :date, comparison: { less_than_or_equal_to: Date.current }` を追加して、未来の日付の登録を禁止
- 関連付け: UserモデルとDailyReportモデルを１対多の関係に設定

### コントローラー層
- Controller: DailyReportsController の #index, #new, #create アクションを実装
- 所有権: #create アクション内で current_user.daily_reports.build を使用し、フォームデータに頼らずにサーバー側で確実なユーザー紐付けを実行
- エラー処理: バリデーション失敗時は、422エラーを返す
- リダイレクト: 成功時はカレンダーを表示する日報一覧ページ (daily_reports_path) へ遷移
- ApplicationControllerで、未ログイン時の日報作成ページへのアクセス及び作成のリクエストで、トップページにリダイレクトさせる処理を追加

###  View・UX/i18n層
- フォーム: 日報作成と編集で共通して使う_form.html.erb を作成し、date と content の入力欄を定義
- エラー表示 (DRY): フォーム全体のエラーサマリーと、フィールドごとのエラー表示（_error_messages.html.erb / _field_error.html.erb）をパーシャル化して再利用性を確保
- i18n: date の比較バリデーションエラーメッセージを「未来の日付として登録できません」と、より自然な日本語に修正
- ヘッダーの日報を書くリンクのパスを正しく動作するように修正

### テスト
- DailyReportのテストデータの定義を追加
- DailyReportモデルのモデルスペックを追加
- 日報作成のリクエストスペックを追加

## スクリーンショット・画面キャプチャ

<img width="1126" height="803" alt="スクリーンショット 2025-12-04 16 55 12" src="https://github.com/user-attachments/assets/3dfe2987-d877-466e-9483-5b7205921503" />

<img width="1126" height="803" alt="スクリーンショット 2025-12-04 16 55 34" src="https://github.com/user-attachments/assets/f6bc765a-fb2b-4dde-84ae-42dd682c822f" />

<img width="1126" height="803" alt="スクリーンショット 2025-12-04 16 55 45" src="https://github.com/user-attachments/assets/dd50bd5f-59f5-4217-9eaa-3c7e16408459" />


## 動作確認

- [x] GET #new: ログイン状態でフォームが表示されること。
- [x] POST (成功): 有効なデータで日報が作成され、日報一覧ページへリダイレクトされること。
- [x] POST (失敗-無効): content が空の場合、DBに保存されず 422 でフォームが再表示され、エラーメッセージが表示されること。
- [x] POST (失敗-未来日): 未来の日付で登録しようとした場合、エラーメッセージ 日報は未来の日付として登録できません が表示されること。
- [x] POST (失敗-認証): 未ログインの場合、トップページにリダイレクトされること。
- [x] RSpec: Model Spec および Request Spec の全テストが通過すること。

## 備考
現時点では日報の内容はただのテキストフォームなので、今後、日報の内容をマークダウンで入力するように修正し、プレビューとフォームを切り替えれるようにする


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can create/edit daily reports (date + content) and access a dedicated form and index page.
  * Navigation updated to link to creating a new daily report.
* **Validation / Bug Fixes**
  * Reports cannot be for future dates; one report per user per date is enforced.
* **Tests**
  * Model and request specs added to cover validations and authenticated flows.
* **Localization**
  * Japanese translations for daily reports and login-required/creation messages added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->