### PR TITLE
feat: 日報一覧を表示するカレンダーページを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'devise-i18n'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection', '~> 1.0'
 
+gem 'simple_calendar'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,8 @@ GEM
     securerandom (0.4.1)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -402,6 +404,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoulda-matchers
+  simple_calendar
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -1,7 +1,15 @@
 class DailyReportsController < ApplicationController
   before_action :authenticate_user!
 
-  def index; end
+  def index
+    start_date = params[:start_date]&.to_date || Date.current
+    start_of_data_month = start_date.beginning_of_month
+    end_of_data_month = start_date.end_of_month
+    @daily_reports = current_user.daily_reports
+                                 .select(:id, :date, :user_id)
+                                 .where(date: start_of_data_month..end_of_data_month)
+                                 .order(date: :asc)
+  end
 
   def new
     @daily_report = current_user.daily_reports.build(date: Date.current)

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -7,6 +7,8 @@ class DailyReportsController < ApplicationController
     @daily_report = current_user.daily_reports.build(date: Date.current)
   end
 
+  def edit; end
+
   def create
     @daily_report = current_user.daily_reports.build(daily_report_params)
     if @daily_report.save

--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -12,7 +12,7 @@ class DailyReportsController < ApplicationController
   end
 
   def new
-    @daily_report = current_user.daily_reports.build(date: Date.current)
+    @daily_report = current_user.daily_reports.build(date: params[:date] || Date.current)
   end
 
   def edit; end

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -1,0 +1,25 @@
+module CalendarHelper
+  def today?(day)
+    day == Date.current
+  end
+
+  def not_current_month?(classes)
+    classes.include?('prev-month') || classes.include?('next-month')
+  end
+
+  def date_number_classes(day, td_classes)
+    classes = 'block font-mono'
+
+    classes << if not_current_month?(td_classes)
+                 ' text-gray-500 opacity-60'
+
+               elsif today?(day)
+                 ' text-green-400 font-bold'
+
+               else
+                 ' text-gray-300'
+               end
+
+    classes
+  end
+end

--- a/app/views/daily_reports/index.html.erb
+++ b/app/views/daily_reports/index.html.erb
@@ -1,6 +1,7 @@
 <div class="container mx-auto px-4 py-8 max-w-4xl">
   <div class="flex justify-between items-center">
     <h1 class="text-3xl font-bold text-white">日報カレンダー</h1>
+    <%= link_to "＋ 日報を書く", new_daily_report_path, class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
   </div>
 
   <div class="rounded-lg shadow-xl mt-6">

--- a/app/views/daily_reports/index.html.erb
+++ b/app/views/daily_reports/index.html.erb
@@ -1,13 +1,10 @@
 <div class="container mx-auto px-4 py-8 max-w-4xl">
-  <h1 class="text-3xl font-bold text-white mb-6 border-b border-gray-700 pb-3">
-    🗓️ 日報カレンダー（工事中）
-  </h1>
-  
-  <p class="text-gray-400 mb-8">
-    日報一覧とカレンダー機能は、次のタスクで実装します。
-    <span class="text-indigo-400">（日報が保存されると、ここに移動します！）</span>
-  </p>
-  
-  <div class="bg-gray-800 p-6 rounded-lg min-h-[400px]">
-    </div>
+  <div class="flex justify-between items-center">
+    <h1 class="text-3xl font-bold text-white">日報カレンダー</h1>
+  </div>
+
+  <div class="rounded-lg shadow-xl mt-6">
+    <%= month_calendar events: @daily_reports, attribute: :date do |day, reports| %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,9 +7,7 @@
 
     <nav class="flex items-center gap-4">
       <% if user_signed_in? %>
-        <%= link_to "＋ 日報を書く", new_daily_report_path, class: "hidden md:inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
-
-        <div class="flex items-center gap-4 border-l border-gray-700 pl-4">
+        <div class="flex items-center gap-4 pl-4">
           <span class="text-sm text-indigo-400 font-medium hidden sm:block">
             <%= current_user.nickname %>
           </span>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,55 @@
+<div class="border-gray-800 rounded-lg shadow-xl border border-gray-800 overflow-hidden">
+  
+  <div class="px-4 py-3 flex justify-between items-center border-b border-gray-800">
+
+    <%= link_to '«', calendar.url_for_previous_view,
+                class: "px-2 py-1.5 text-gray-300 rounded hover:bg-gray-600 transition" %>
+
+    <div class="flex-grow text-center">
+      <time datetime="<%= start_date.strftime('%Y-%m') %>" class="text-xl font-bold text-indigo-400">
+        <%= start_date.year %>年 <%= start_date.month %>月 
+      </time>
+    </div>
+    
+    <%= link_to '»', calendar.url_for_next_view,
+                class: "px-2 py-1.5 text-gray-300 rounded hover:bg-gray-600 transition" %>
+  </div>
+
+  <table class="w-full table-fixed">
+    <thead>
+      <tr class="border-b border-gray-800">
+        <% date_range.slice(0, 7).each do |day| %>
+          <th class="py-2 text-xs font-semibold text-gray-400">
+            <%= t('date.abbr_day_names')[day.wday] %>
+          </th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <% td_classes = calendar.td_classes_for(day) %>
+            <% daily_reports = calendar.sorted_events_for(day) %>
+            <%= content_tag :td, class: "py-8" do %>
+              <% if daily_reports.any? %>
+                <div class="mx-auto flex items-center justify-center w-10 h-10 rounded-full bg-indigo-400 text-white">
+                  <%= link_to day.day,
+                      edit_daily_report_path(daily_reports.first),
+                      class: date_number_classes(day, td_classes) %>
+                </div>
+              <% else %>
+                <div class="mx-auto flex items-center justify-center w-10 h-10 text-white">
+                  <%= link_to day.day,
+                      new_daily_report_path(date: day),
+                      class: date_number_classes(day, td_classes) %>
+                </div>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/spec/helpers/calendar_helper_spec.rb
+++ b/spec/helpers/calendar_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe CalendarHelper, type: :helper do
+  describe '#today?' do
+    it '引数が今日の日付であればtrueを返すこと' do
+      expect(helper.today?(Date.current)).to be true
+      expect(helper.today?(Date.current.yesterday)).to be false
+    end
+  end
+
+  describe '#date_number_classes' do
+    let(:today) { Date.current }
+    let(:td_classes) { ['day'] }
+
+    it '今日の日付であれば緑色のクラスが適用されること' do
+      expect(helper.date_number_classes(today, td_classes)).to include('text-green-400')
+    end
+
+    it '今月以外であれば薄い色と透過度が適用されること' do
+      non_current_classes = %w[day prev-month]
+      expect(helper.date_number_classes(today, non_current_classes)).to include('opacity-60')
+      expect(helper.date_number_classes(today, non_current_classes)).not_to include('text-green-400')
+    end
+  end
+end


### PR DESCRIPTION
## 概要

日報の一覧画面をカレンダー形式で実装しました。これにより、ユーザーはカレンダー上で日報の有無を視覚的に確認し、日付をクリックすることで、該当日の日報の編集・新規作成ページへ直接遷移できるようになりました。

## 関連 Issue

- #11 

## 対応内容

- カレンダー表示用に simple_calendar を導入
- カレンダーから日報の編集ページへ遷移できるように機能を追加
- カレンダーで表示中の月に紐づく日報一覧を取得する処理を追加
- カレンダーページのビューを新規作成
- 日報作成リンクの配置をヘッダーからカレンダーページへ移動
- カレンダーの日付をクリックした際、その日付が日報作成フォームに自動入力されるように改善
- カレンダー関連のヘルパーに対するテストを追加
- 日報一覧（index）のリクエストスペックを追加

## スクリーンショット・画面キャプチャ

<img width="1126" height="803" alt="スクリーンショット 2025-12-09 16 40 49" src="https://github.com/user-attachments/assets/e6560ecb-c8e7-4c4d-89e7-920f5cdfcbc9" />

## 動作確認

- [x] ログイン後、日報一覧ページにアクセスできること
- [x] カレンダーの表示が、現在の月になっていること（デフォルト）
- [x] 「<<」「>>」ボタンをクリックし、カレンダーの表示が正しく切り替わること
- [x] 日報がある日をクリックし、編集ページ（edit）に遷移すること
- [x] 日報がない日をクリックし、新規作成ページ（new）に遷移し、クリックした日付が正しく入力されていること
- [x] 他ユーザーの日報のデータがカレンダーに表示されないこと

## 備考

日報編集ページは仮の状態です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added calendar interface for viewing daily reports organized by date
  * Navigate between months to view reports from different periods
  * Create new daily reports or edit existing ones directly from the calendar view
  * Reports display with visual indicators for current vs. adjacent months

* **Tests**
  * Added comprehensive test coverage for calendar functionality and daily report views

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->