### PR TITLE
feat: 日報削除機能を実装

### DIFF
--- a/app/controllers/daily_reports_controller.rb
+++ b/app/controllers/daily_reports_controller.rb
@@ -37,6 +37,14 @@ class DailyReportsController < ApplicationController
     end
   end
 
+  def destroy
+    @daily_report = current_user.daily_reports.find(params[:id])
+
+    @daily_report.destroy!
+
+    redirect_to daily_reports_path, notice: t('.success'), status: :see_other
+  end
+
   private
 
   def daily_report_params

--- a/app/views/daily_reports/_form.html.erb
+++ b/app/views/daily_reports/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: daily_report, local: true, data: { turbo: false }, class: "space-y-6" do |f| %>
+<%= form_with model: daily_report, class: "space-y-6" do |f| %>
   
   <%= render 'shared/error_messages', model: daily_report, subject: '日報の保存' %>
 
@@ -24,7 +24,16 @@
     <%= render 'shared/field_error', f: f, field: :content %>
   </div>
 
-  <div class="flex justify-end pt-4 border-t border-gray-700">
+  <div class="flex justify-end pt-4 gap-2 border-t border-gray-700">
+    <% if daily_report.persisted? %>
+      <%= link_to '削除する', 
+        daily_report_path(daily_report), 
+        data: { turbo_method: :delete, turbo_confirm: "本当に削除してもよろしいですか？" },
+        class: "px-6 py-3 text-red-400 hover:text-red-300 hover:bg-red-500/10 font-bold rounded-md transition duration-200 "
+      %>
+    <% else %>
+      <div></div>
+    <% end %>
     <%= f.submit "日報を保存", class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg shadow-indigo-900/30" %>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,3 +24,6 @@ ja:
     update:
       success: "日報を更新しました"
       failure: "日報の保存に失敗しました"
+    destroy:
+      success: "日報を削除しました"
+      failure: "日報の削除に失敗しました"

--- a/spec/requests/daily_report_spec.rb
+++ b/spec/requests/daily_report_spec.rb
@@ -204,4 +204,34 @@ RSpec.describe 'DailyReports', type: :request do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      it '日報が削除され、カレンダーページにリダイレクトすること' do
+        expect do
+          delete daily_report_path(daily_report)
+        end.to change(DailyReport, :count).by(-1)
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(daily_reports_path)
+      end
+
+      it '他のユーザーの日報を削除しようとすると404エラーが発生すること' do
+        other_user = create(:user)
+        other_report = create(:daily_report, user: other_user)
+        expect { delete daily_report_path(other_report) }.not_to change(DailyReport, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '未ログインの場合' do
+      it '日報が削除されず、トップページにリダイレクトされること' do
+        expect do
+          delete daily_report_path(daily_report)
+        end.not_to change(DailyReport, :count)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

作成済みの日報を削除する機能を実装しました。 間違って作成した場合や不要になった日報を、編集画面から削除できるようにしました。

## 関連 Issue

- #13 

## 対応内容

### コントローラー 

- destroy アクションを追加
- current_user.daily_reports.find(params[:id]) を使用し、ログインユーザー本人の日報のみ削除可能に制限（認可制御）
- 削除成功後は、Turbo Driveに対応するためステータスコード 303 See Other でカレンダー一覧へリダイレクト

### ビュー

- 編集フォームの下部に「削除する」リンクを追加
- data-turbo-confirm を使用し、削除実行前にブラウザ標準の確認ダイアログを表示
- UI調整：誤操作防止のため、保存ボタンとは左右に配置を分け、スタイルも赤文字のリンク風（ゴーストボタン）にして区別

### テスト

- DELETE #destroy のリクエストスペックを追加
 - 正常系：削除後に１件レコードが減り、一覧へリダイレクトされること
 - 異常系：他人の日報を削除しようとしても削除されず、トップへリダイレクトされること
 - 異常系：未ログイン時は削除できず、ログイン画面（またはトップ）へリダイレクトされること

## スクリーンショット・画面キャプチャ

<img width="1126" height="803" alt="スクリーンショット 2025-12-10 17 31 40" src="https://github.com/user-attachments/assets/e99d5536-6987-428f-85f0-3c5a2dd540fb" />
<img width="1126" height="803" alt="スクリーンショット 2025-12-10 17 31 49" src="https://github.com/user-attachments/assets/bd9b7747-faaa-4297-a3a6-1881c7aa8213" />


## 動作確認

- [x] 編集画面（保存済みの日報）にのみ「削除する」ボタンが表示されていること
- [x] 新規作成画面には「削除する」ボタンが表示されていないこと
- [x] 削除ボタンクリック時に確認ダイアログが表示され、キャンセルすると削除されないこと
- [x] 削除実行後、日報がDBから消え、カレンダー一覧画面に遷移すること
- [x] 他人の日報IDに対して削除リクエストを送っても削除されず、適切にリダイレクトされること

## 備考


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily reports can now be deleted by their owners. A confirmation-protected delete button appears on existing reports, preventing accidental removal. Upon successful deletion, users receive a confirmation message. Security measures ensure users can only delete their own reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->