### PR TITLE
feat: 技術記事作成機能を実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,25 @@
+class ArticlesController < ApplicationController
+  before_action :authenticate_user!, only: %i[new create]
+
+  def index; end
+
+  def new
+    @article = current_user.articles.build(status: :draft)
+  end
+
+  def create
+    @article = current_user.articles.build(article_params)
+
+    if @article.save
+      redirect_to articles_path, notice: t('.success')
+    else
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(:title, :content, :status)
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,20 @@
+class Article < ApplicationRecord
+  belongs_to :user
+
+  enum :status, { draft: 0, published: 1 }
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :content, presence: true
+  validates :status, presence: true
+  validates :published_at, presence: true, if: :published?
+
+  before_validation :set_published_at
+
+  private
+
+  def set_published_at
+    return unless published? && published_at.nil?
+
+    self.published_at = Time.current
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]
 
   has_many :daily_reports, dependent: :destroy
+  has_many :articles, dependent: :destroy
 
   def self.from_omniauth(auth)
     return nil if auth.info.email.blank?

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,0 +1,38 @@
+  <%= form_with model: @article, class: "space-y-6" do |f| %>
+    <%= render 'shared/error_messages', model: f.object, subject: '技術記事の保存' %>
+
+    <div>
+      <%= f.label :title, "タイトル", class: "block text-sm font-medium text-gray-400 mb-1" %>
+      <%= f.text_field :title, 
+          class: "w-full p-3 bg-gray-800 border border-gray-700 rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500 placeholder-gray-500",
+          placeholder: "記事のタイトルを入力してください" %>
+      <%= render 'shared/field_error', f: f, field: :title %>
+    </div>
+
+    <div>
+      <%= f.label :content, "本文 (Markdown)", class: "block text-sm font-medium text-gray-400 mb-1" %>
+      <%= f.text_area :content, rows: 20, 
+          class: "w-full p-3 bg-gray-800 border border-gray-700 rounded-lg text-white focus:ring-indigo-500 focus:border-indigo-500 font-mono text-sm",
+          placeholder: "技術的な知見をMarkdownで共有しましょう" %>
+      <%= render 'shared/field_error', f: f, field: :content %>
+    </div>
+
+    <div class="bg-gray-800 p-4 rounded-lg border border-gray-700">
+      <span class="block text-sm font-medium text-gray-400 mb-2">公開設定</span>
+      <div class="flex gap-6">
+        <label class="flex items-center cursor-pointer">
+          <%= f.radio_button :status, :draft, class: "w-4 h-4 text-indigo-600 bg-gray-700 border-gray-600 focus:ring-indigo-500" %>
+          <span class="ml-2 text-sm text-gray-300">下書き保存</span>
+        </label>
+        <label class="flex items-center cursor-pointer">
+          <%= f.radio_button :status, :published, class: "w-4 h-4 text-indigo-600 bg-gray-700 border-gray-600 focus:ring-indigo-500" %>
+          <span class="ml-2 text-sm text-gray-300 font-bold">公開する</span>
+        </label>
+      </div>
+  <%= render 'shared/field_error', f: f, field: :status %>
+    </div>
+
+    <div class="flex justify-end pt-4">
+      <%= f.submit "記事を保存", class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg" %>
+    </div>
+  <% end %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold text-white mb-6">新しい技術記事を作成</h1>
+  <%= render 'form' %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,12 +3,17 @@ ja:
     models:
       user: ユーザー
       daily_report: 日報
+      articles: 技術記事
     attributes:
       user:
         email: メールアドレス
       daily_report:
         date: 日付
         content: 内容
+      article:
+        title: タイトル
+        content: 内容
+        status: ステータス
     errors:
       models:
         daily_report:
@@ -27,3 +32,7 @@ ja:
     destroy:
       success: "日報を削除しました"
       failure: "日報の削除に失敗しました"
+  articles:
+    create:
+      success: "技術記事を作成しました"
+      failure: "技術記事の保存に失敗しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :daily_reports
+  resources :articles, only: %i[index new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20251210101653_create_articles.rb
+++ b/db/migrate/20251210101653_create_articles.rb
@@ -1,0 +1,16 @@
+class CreateArticles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :articles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :content, null: false
+      t.integer :status, null: false, default: 0
+      t.datetime :published_at
+
+      t.timestamps
+    end
+
+    add_index :articles, :status
+    add_index :articles, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_02_133821) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_10_101653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "articles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["published_at"], name: "index_articles_on_published_at"
+    t.index ["status"], name: "index_articles_on_status"
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
 
   create_table "daily_reports", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -40,5 +53,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_02_133821) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "articles", "users"
   add_foreign_key "daily_reports", "users"
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :article do
+    association :user
+    title { 'テスト記事のタイトル' }
+    content { 'これはテスト記事の本文です。Markdown記法などもテストできます。' }
+    status { :draft }
+    published_at { nil }
+
+    trait :published do
+      status { :published }
+      published_at { Time.current }
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  describe 'Validation' do
+    let(:user) { create(:user) }
+
+    context '正常系' do
+      it 'すべての属性が正しければ有効であること' do
+        article = build(:article, user: user)
+        expect(article).to be_valid
+      end
+
+      it 'ステータスがdraftのとき、published_atがnilでも有効であること' do
+        article = build(:article, status: :draft, published_at: nil)
+        expect(article).to be_valid
+      end
+    end
+
+    context '異常系' do
+      it { is_expected.to validate_presence_of(:title) }
+      it { is_expected.to validate_length_of(:title).is_at_most(100) }
+      it { is_expected.to validate_presence_of(:content) }
+      it { is_expected.to validate_presence_of(:status) }
+    end
+  end
+
+  describe 'コールバック (before_validation)' do
+    context 'ステータスをpublishedにして保存する場合' do
+      it 'published_atがnilなら、現在時刻が自動でセットされること' do
+        article = build(:article, status: :published, published_at: nil)
+        article.valid?
+        expect(article.published_at).to be_present
+        expect(article.published_at).to be_within(1.second).of(Time.current)
+      end
+
+      it 'published_atに既に値があるなら、上書きされないこと' do
+        old_date = 1.day.ago
+        article = build(:article, status: :published, published_at: old_date)
+        article.valid?
+        expect(article.published_at).to be_within(1.second).of(old_date)
+      end
+    end
+
+    context 'ステータスをdraftにして保存する場合' do
+      it 'published_atがnilのままであること' do
+        article = build(:article, status: :draft, published_at: nil)
+        article.valid?
+        expect(article.published_at).to be_nil
+      end
+    end
+  end
+
+  describe 'Association' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'enum' do
+    it { is_expected.to define_enum_for(:status).with_values(draft: 0, published: 1) }
+  end
+end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe 'Articles', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+
+  describe 'GET #new' do
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      it '正常にレスポンスを返し、新しい技術記事オブジェクトを保持すること' do
+        get new_article_path
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('新しい技術記事を作成')
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'トップページにリダイレクトされること' do
+        get new_article_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_params) do
+      { article: attributes_for(:article) }
+    end
+    let(:invalid_params) do
+      { article: attributes_for(:article, title: nil) }
+    end
+
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      context 'パラメータが有効な場合' do
+        it '技術記事がDBに保存され、ユーザーと紐付いていること' do
+          expect do
+            post articles_path, params: valid_params
+          end.to change(Article, :count).by(1)
+
+          expect(Article.last.user).to eq(user)
+        end
+
+        it '記事一覧ページにリダイレクトすること' do
+          post articles_path, params: valid_params
+          expect(response).to redirect_to(articles_path)
+        end
+      end
+
+      context 'パラメータが無効な場合' do
+        it '技術記事がDBに保存されず、フォームが再表示されること' do
+          expect do
+            post articles_path, params: invalid_params
+          end.not_to change(Article, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include(I18n.t('articles.create.failure'))
+        end
+      end
+    end
+
+    context '未ログインの場合' do
+      it '技術記事が保存されず、トップページにリダイレクトされること' do
+        expect do
+          post articles_path, params: valid_params
+        end.not_to change(Article, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

技術記事の新規作成機能を実装しました。 これによって、ユーザーは自身の技術記事を執筆・保存（公開/下書き）できるようになります。

## 関連 Issue

- #14 

## 対応内容

### Model
- articles テーブルのマイグレーションファイル作成
- Article モデルの作成
- User モデル との関連付け
- status カラムの enum 定義（下書き/公開）
- タイトル・本文のバリデーション設定
- published_at（公開日時）のカスタムバリデーション実装

### Controller
- ArticlesController の作成
- index: 記事一覧表示（現時点では作成確認用）
- new: 新規作成フォーム表示
- create: 記事保存処理（成功時は一覧へ、失敗時はフォーム再表示）

### View
- 記事作成フォーム（_form.html.erb）のパーシャル化
- 新規作成画面（new.html.erb）の実装
- 一覧画面（index.html.erb）の仮実装

### Test
- Articleの テストデータの定義
- Articleのモデルスペック
- 技術記事作成のリクエストスペック

## スクリーンショット・画面キャプチャ

<img width="1116" height="811" alt="スクリーンショット 2025-12-13 22 51 13" src="https://github.com/user-attachments/assets/d6e5b85b-27c0-445d-a182-31c0a137b381" />

<img width="1116" height="811" alt="スクリーンショット 2025-12-13 22 51 27" src="https://github.com/user-attachments/assets/13254c27-fdac-494e-8ccf-991232210776" />

<img width="1116" height="811" alt="スクリーンショット 2025-12-13 22 51 50" src="https://github.com/user-attachments/assets/edd27fe3-c084-4660-8755-1a96a0d16f39" />

## 動作確認
- [x] http://localhost:3000/articles/new にアクセスし、フォームが表示されること
- [x] タイトル・本文・公開設定を入力して「登録する」を押し、DBに保存されること
- [x] 保存後、記事一覧画面（http://localhost:3000/articles）へリダイレクトされること
- [x] 必須項目を空にして送信した際、エラーメッセージが表示されること
- [x] テストが通ること（bundle exec rspec spec/models/article_spec.rb spec/requests/articles_spec.rb）

## 備考

技術記事一覧画面は技術記事作成後の画面遷移の確認のため仮の実装。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create and manage technical articles with title and content.
  * Articles support draft and published states with automatic publication timestamps.
  * Articles are linked to user accounts for tracking ownership.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->