### PR TITLE
技術記事詳細機能の実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,15 +1,19 @@
 class ArticlesController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create]
+  before_action :authenticate_user!, only: %i[new create edit]
 
   def index
     @articles = Article.published.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
-  def show; end
+  def show
+    @article = Article.published.includes(:user).find(params[:id])
+  end
 
   def new
     @article = current_user.articles.build(status: :draft)
   end
+
+  def edit; end
 
   def create
     @article = current_user.articles.build(article_params)

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,71 @@
+<div class="min-h-screen py-10">
+  <div class="container mx-auto px-4 max-w-3xl">
+
+    <article class="rounded-lg overflow-hidden">
+
+      <header class="px-8 pt-10 pb-8">
+        <div class="flex items-start justify-between mb-4">
+          
+          <div class="text-gray-400 text-sm flex flex-wrap items-center gap-x-4 gap-y-1">
+            <span><%= l @article.created_at, format: :long %> に公開</span>
+            <% if @article.updated_at > @article.created_at %>
+              <span class="flex items-center text-gray-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5 mr-1">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 4.992l9.19-9.19M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <%= l @article.updated_at, format: :long %> に更新
+              </span>
+            <% end %>
+          </div>
+
+          <% if current_user == @article.user %>
+            <%= link_to edit_article_path(@article), class: "group flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-gray-400 bg-gray-800/50 border border-gray-700 rounded-full hover:bg-gray-700 hover:text-white transition-all" do %>
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 group-hover:text-blue-400 transition-colors">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+              </svg>
+              <span>編集する</span>
+            <% end %>
+          <% end %>
+
+        </div>
+        
+        <h1 class="text-3xl md:text-4xl font-extrabold text-white tracking-tight leading-tight">
+          <%= @article.title %>
+        </h1>
+      </header>
+
+      <div class="px-8 pb-12 prose prose-invert prose-blue max-w-none prose-headings:font-bold prose-a:text-blue-400 hover:prose-a:text-blue-300 prose-img:rounded-lg leading-relaxed">
+        <%= simple_format(@article.content) %>
+      </div>
+
+      <footer class="border-t border-gray-700 p-8">
+        <div class="flex items-start sm:items-center space-x-4">
+          
+          <%= link_to "#", class: "flex-shrink-0" do %>
+            <div class="w-16 h-16 rounded-full bg-gray-700 flex items-center justify-center text-gray-200 text-xl font-bold ring-4 ring-gray-800">
+              <%= @article.user.nickname&.first&.upcase || '?' %>
+            </div>
+          <% end %>
+
+          <div class="flex-1">
+            <h3 class="text-lg font-bold text-gray-200">
+              <%= link_to @article.user.nickname, "#", class: "hover:underline" %>
+            </h3>
+            
+            <p class="text-gray-300 text-sm mt-1">
+              技術記事を投稿しています。Ruby on Rails とフロントエンド技術に興味があります。
+            </p>
+          </div>
+        </div>
+      </footer>
+    </article>
+
+    <div class="mt-8 text-center">
+      <%= link_to articles_path, class: "group inline-flex items-center px-4 py-2 border border-gray-600 rounded-full text-gray-300 hover:bg-gray-800 transition-all" do %>
+        <span class="group-hover:-translate-x-1 transition-transform">←</span>
+        <span class="ml-2">記事一覧に戻る</span>
+      <% end %>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :daily_reports
-  resources :articles, only: %i[index show new create]
+  resources :articles, only: %i[index show new create edit]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要

技術記事の詳細ページを表示する機能を実装しました。記事一覧から記事をクリックすると、記事の詳細情報（タイトル、本文、作成日時、更新日時、作成者情報）を表示できます。

## 関連 Issue

- #16 

## 対応内容

- 記事詳細ページのコントローラーアクション（`show`）を実装
- 記事詳細ページのビュー（`show.html.erb`）を実装
  - 記事タイトル、本文の表示
  - 作成日時・更新日時の表示
  - 作成者情報の表示
  - 記事作成者のみ編集ボタンを表示
  - 記事一覧への戻るリンク
- ルーティングに`show`アクションを追加
- 記事詳細機能のリクエストスペックを追加
  - 未ログイン時の表示確認
  - 記事作成者ログイン時の編集ボタン表示確認
  - 記事作成者以外ログイン時の編集ボタン非表示確認
  - 下書き記事へのアクセス時の404エラー確認
  - 存在しない記事IDへのアクセス時の404エラー確認

## スクリーンショット・画面キャプチャ

技術記事詳細ページ（未ログイン）
<img width="1114" height="808" alt="スクリーンショット 2025-12-17 16 45 43" src="https://github.com/user-attachments/assets/4eab3ccf-d12c-4042-be39-16cc4388c492" />

技術記事詳細ページ（ログイン済みかつ自分のページ）
<img width="1114" height="808" alt="スクリーンショット 2025-12-17 16 46 34" src="https://github.com/user-attachments/assets/7d82005a-d9b1-4bd9-973c-86d7f2e28725" />

## 動作確認

- [x] 記事一覧から記事をクリックして詳細ページが表示されること
- [x] 記事のタイトル、本文、作成日時が正しく表示されること
- [x] 更新日時が作成日時より後の場合のみ表示されること
- [x] 記事作成者のみ編集ボタンが表示されること
- [x] 下書き記事にアクセスした場合404エラーが返されること
- [x] 存在しない記事IDにアクセスした場合404エラーが返されること
- [x] テストが全て通ること

## 備考

- エラーハンドリングはRailsの標準動作（`ActiveRecord::RecordNotFound`が自動的に404として処理される）を使用しています
- ユーザープロフィールリンクは未実装のため、現時点では`#`となっています（プロフィール機能実装時に修正予定）

