### PR TITLE
feat: 技術記事編集機能を実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create edit]
+  before_action :authenticate_user!, only: %i[new create edit update]
 
   def index
     @articles = Article.published.includes(:user).order(created_at: :desc).page(params[:page])
@@ -13,7 +13,9 @@ class ArticlesController < ApplicationController
     @article = current_user.articles.build(status: :draft)
   end
 
-  def edit; end
+  def edit
+    @article = current_user.articles.find(params[:id])
+  end
 
   def create
     @article = current_user.articles.build(article_params)
@@ -22,6 +24,15 @@ class ArticlesController < ApplicationController
       redirect_to articles_path, notice: t('.success')
     else
       render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    @article = current_user.articles.find(params[:id])
+    if @article.update(article_params)
+      redirect_to article_path(@article), notice: t('.success')
+    else
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,7 +6,10 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.published.includes(:user).find(params[:id])
+    @article = Article.includes(:user).find(params[:id])
+    return if @article.published? || (user_signed_in? && @article.user == current_user)
+
+    raise ActiveRecord::RecordNotFound
   end
 
   def new

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_with model: @article, class: "space-y-6" do |f| %>
+  <%= form_with model: article, class: "space-y-6" do |f| %>
     <%= render 'shared/error_messages', model: f.object, subject: '技術記事の保存' %>
 
     <div>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold text-white mb-6">記事を編集</h1>
+  <%= render 'form', article: @article %>
+</div>
+

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,4 +1,4 @@
 <div class="max-w-4xl mx-auto px-4 py-8">
   <h1 class="text-2xl font-bold text-white mb-6">新しい技術記事を作成</h1>
-  <%= render 'form' %>
+  <%= render 'form', article: @article %>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -7,7 +7,11 @@
         <div class="flex items-start justify-between mb-4">
           
           <div class="text-gray-400 text-sm flex flex-wrap items-center gap-x-4 gap-y-1">
-            <span><%= l @article.created_at, format: :long %> に公開</span>
+            <% if @article.published? %>
+              <span><%= l @article.created_at, format: :long %> に公開</span>
+            <% else %>
+              <span class="text-gray-500">下書き</span>
+            <% end %>
             <% if @article.updated_at > @article.created_at %>
               <span class="flex items-center text-gray-500">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5 mr-1">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -36,6 +36,9 @@ ja:
     create:
       success: 技術記事を作成しました
       failure: 技術記事の保存に失敗しました
+    update:
+      success: 技術記事を更新しました
+      failure: 技術記事の保存に失敗しました
   views:
     pagination:
       previous: <

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,27 +19,25 @@ ja:
         daily_report:
           attributes:
             date:
-              less_than_or_equal_to: "は、未来の日付として登録できません"
+              less_than_or_equal_to: は、未来の日付として登録できません
   common:
-    login_required: "ログインが必要です。"
+    login_required: ログインが必要です。
   daily_reports:
     create:
-      success: "日報を作成しました"
-      failure: "日報の保存に失敗しました"
+      success: 日報を作成しました
+      failure: 日報の保存に失敗しました
     update:
-      success: "日報を更新しました"
-      failure: "日報の保存に失敗しました"
+      success: 日報を更新しました
+      failure: 日報の保存に失敗しました
     destroy:
-      success: "日報を削除しました"
-      failure: "日報の削除に失敗しました"
+      success: 日報を削除しました
+      failure: 日報の削除に失敗しました
   articles:
     create:
-      success: "技術記事を作成しました"
-      failure: "技術記事の保存に失敗しました"
+      success: 技術記事を作成しました
+      failure: 技術記事の保存に失敗しました
   views:
     pagination:
-      previous: "<"
-      next: ">"
-      truncate: "..."
-      first: "<<"
-      last: ">>"
+      previous: <
+      next: >
+      truncate: ...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :daily_reports
-  resources :articles, only: %i[index show new create edit]
+  resources :articles, only: %i[index show new create edit update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -62,46 +62,68 @@ RSpec.describe 'Articles', type: :request do
 
   describe 'GET #show' do
     let(:other_user) { create(:user) }
-    let!(:article) { create(:article, :published, user: user, title: '詳細ページのテスト') }
-    let!(:draft_article) { create(:article, :draft, user: user) }
+    let!(:published_article) { create(:article, :published, user: user, title: '公開記事') }
+    let!(:draft_article) { create(:article, :draft, user: user, title: '下書き記事') }
 
-    context '未ログイン（ゲスト）の場合' do
-      it '正常に表示され、編集ボタンが表示されないこと' do
-        get article_path(article)
+    context '公開記事の場合' do
+      context '記事の作成者がログインしている場合' do
+        before { sign_in user }
 
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include(article.title)
-        expect(response.body).not_to include(edit_article_path(article))
+        it '正常に表示され、編集ボタンが表示されること' do
+          get article_path(published_article)
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(published_article.title)
+          expect(response.body).to include(edit_article_path(published_article))
+        end
+      end
+
+      context '未ログインの場合' do
+        it '正常に表示され、編集ボタンが表示されないこと' do
+          get article_path(published_article)
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(published_article.title)
+          expect(response.body).not_to include(edit_article_path(published_article))
+        end
+      end
+
+      context '記事の作成者以外がログインしている場合' do
+        before { sign_in other_user }
+
+        it '正常に表示され、編集ボタンが表示されないこと' do
+          get article_path(published_article)
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(published_article.title)
+          expect(response.body).not_to include(edit_article_path(published_article))
+        end
       end
     end
 
-    context '記事の作成者がログインしている場合' do
-      before { sign_in user }
+    context '下書き記事の場合' do
+      context '記事の作成者がログインしている場合' do
+        before { sign_in user }
 
-      it '編集ボタンが表示されること' do
-        get article_path(article)
-
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include(edit_article_path(article))
+        it '正常に表示されること' do
+          get article_path(draft_article)
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(draft_article.title)
+          expect(response.body).to include('下書き')
+        end
       end
-    end
 
-    context '記事の作成者以外がログインしている場合' do
-      before { sign_in other_user }
-
-      it '編集ボタンが表示されないこと' do
-        get article_path(article)
-
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include(article.title)
-        expect(response.body).not_to include(edit_article_path(article))
+      context '未ログインの場合' do
+        it '404エラーが発生すること' do
+          get article_path(draft_article)
+          expect(response).to have_http_status(:not_found)
+        end
       end
-    end
 
-    context '下書き記事にアクセスした場合' do
-      it '404エラーが発生すること' do
-        get article_path(draft_article)
-        expect(response).to have_http_status(:not_found)
+      context '記事の作成者以外がログインしている場合' do
+        before { sign_in other_user }
+
+        it '404エラーが発生すること' do
+          get article_path(draft_article)
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
 

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -180,4 +180,95 @@ RSpec.describe 'Articles', type: :request do
       end
     end
   end
+
+  describe 'GET #edit' do
+    let(:other_user) { create(:user) }
+    let!(:article) { create(:article, :published, user: user, title: '編集ページのテスト') }
+    let!(:draft_article) { create(:article, :draft, user: user, title: '下書き記事') }
+
+    context 'ログイン済みで自分の記事の場合' do
+      before { sign_in user }
+
+      it '正常に表示されること' do
+        get edit_article_path(article)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('記事を編集')
+      end
+
+      it '下書き記事も編集可能であること' do
+        get edit_article_path(draft_article)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include('記事を編集')
+      end
+    end
+
+    context 'ログイン済みで他人の記事の場合' do
+      before { sign_in other_user }
+
+      it '404エラーが発生すること' do
+        get edit_article_path(article)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'トップページにリダイレクトされること' do
+        get edit_article_path(article)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:other_user) { create(:user) }
+    let!(:article) { create(:article, :published, user: user, title: '更新前のタイトル', content: '更新前の内容') }
+    let(:valid_params) do
+      { article: { title: '更新後のタイトル', content: '更新後の内容', status: :published } }
+    end
+    let(:invalid_params) do
+      { article: { title: nil, content: '更新後の内容', status: :published } }
+    end
+
+    context 'ログイン済みで自分の記事の場合' do
+      before { sign_in user }
+
+      context 'パラメータが有効な場合' do
+        it '正常に更新されること' do
+          patch article_path(article), params: valid_params
+          article.reload
+          expect(article.title).to eq('更新後のタイトル')
+          expect(article.content).to eq('更新後の内容')
+        end
+
+        it '更新後、記事詳細ページにリダイレクトされること' do
+          patch article_path(article), params: valid_params
+          expect(response).to redirect_to(article_path(article))
+        end
+      end
+
+      context 'パラメータが無効な場合' do
+        it 'フォームが再表示されること' do
+          patch article_path(article), params: invalid_params
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include('記事を編集')
+        end
+      end
+    end
+
+    context 'ログイン済みで他人の記事の場合' do
+      before { sign_in other_user }
+
+      it '404エラーが発生すること' do
+        patch article_path(article), params: valid_params
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'トップページにリダイレクトされること' do
+        patch article_path(article), params: valid_params
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

技術記事の編集機能を実装しました。記事詳細ページから編集ボタンをクリックすると、記事のタイトル、本文、公開設定を編集できます。既存のフォームパーシャルを共通利用し、新規作成と編集で同じフォームを使用します。

## 関連 Issue

- #17 

## 対応内容

- 記事編集ページのコントローラーアクション（`edit`、`update`）を実装
  - 自分の記事（公開・下書き両方）のみ編集可能
  - 更新後は記事詳細ページにリダイレクト
- 記事編集ページのビュー（`edit.html.erb`）を実装
  - 既存の`_form`パーシャルを共通利用
- フォームパーシャルをローカル変数で受け取るようにリファクタリング
  - インスタンス変数の直接参照をやめ、呼び出し側でローカル変数として渡すように変更
  - プロジェクト内の一貫性を向上（`daily_reports/_form.html.erb`と同じパターン）
- ルーティングに`update`アクションを追加
- 記事編集機能のリクエストスペックを追加
  - ログイン済みで自分の記事の場合：正常に編集・更新できること
  - ログイン済みで他人の記事の場合：404 エラーが発生すること
  - 未ログインの場合：トップページにリダイレクトされること
  - 下書き記事も編集可能であること
  - バリデーションエラー時：フォームが再表示されること
- ロケールファイルに`articles.update`メッセージを追加
- コードスタイルの統一（YAML ファイルの不要なクォーテーションを削除）

## スクリーンショット・画面キャプチャ

技術記事編集画面
<img width="1114" height="808" alt="スクリーンショット 2025-12-17 20 49 26" src="https://github.com/user-attachments/assets/9cedf739-5856-462a-9939-c850f29af577" />

## 動作確認

- [x] 記事詳細ページから編集ボタンをクリックして編集ページが表示されること
- [x] 記事のタイトル、本文、公開設定を編集できること
- [x] 更新後、記事詳細ページにリダイレクトされること
- [x] バリデーションエラー時、フォームが再表示されること
- [x] 他人の記事を編集しようとした場合 404 エラーが返されること
- [x] 下書き記事も編集できること
- [x] テストが全て通ること

## 備考

- コントローラーでは`before_action`で`set_article`を使わず、各アクション内で明示的に`@article`を設定するように実装しました（`DailyReportsController`と同じパターン）
- フォームパーシャルはローカル変数で受け取るように変更し、プロジェクト内の一貫性を向上させました

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add article editing/updating for owners, gate draft visibility in show, refactor form partial, and add corresponding routes, i18n, and request specs.
> 
> - **Backend**
>   - Add `edit`/`update` to `ArticlesController`; require auth for `update` and scope finds to `current_user` in edit/update.
>   - Change `show` to load any `Article` then 404 unless published or owned by current user.
>   - Update routes to include `articles#update`.
> - **Views**
>   - New `articles/edit.html.erb` using shared `_form`.
>   - Refactor `_form` to accept local `article`; update `new.html.erb` to pass it.
>   - `show.html.erb`: display draft badge when not published; show Edit button only to the owner.
> - **I18n**
>   - Add `articles.update` success/failure messages; normalize YAML quotes and pagination strings.
> - **Tests**
>   - Add request specs for `show` (draft visibility, edit button conditions), `edit`, and `update` (success/validation errors, authz: owner/other/guest).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d543a79e49077a200cc6f42ecc0c2f014c5c7685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added article update capability so authors can save changes to their own articles with proper access checks.

* **Style**
  * Improved edit screen layout and header; updated form binding to ensure edit/new forms use the correct article context.
  * Show view now indicates draft status when an article is unpublished.

* **Chores**
  * Cleaned up Japanese translation strings for consistency.

* **Tests**
  * Expanded request specs to cover show/edit/update flows, authorization, and validation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->