### PR TITLE
feat: 技術記事削除機能の実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create edit update]
+  before_action :authenticate_user!, only: %i[new create edit update destroy]
 
   def index
     @articles = Article.published.includes(:user).order(created_at: :desc).page(params[:page])
@@ -37,6 +37,13 @@ class ArticlesController < ApplicationController
     else
       render :edit, status: :unprocessable_content
     end
+  end
+
+  def destroy
+    @article = current_user.articles.find(params[:id])
+    return redirect_to articles_path, alert: t('.failure') unless @article.destroy
+
+    redirect_to articles_path, notice: t('.success'), status: :see_other
   end
 
   private

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -32,7 +32,16 @@
   <%= render 'shared/field_error', f: f, field: :status %>
     </div>
 
-    <div class="flex justify-end pt-4">
+    <div class="flex justify-end pt-4 gap-2 border-t border-gray-700">
+      <% if article.persisted? %>
+        <%= link_to '削除する', 
+          article_path(article), 
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除してもよろしいですか？" },
+          class: "px-6 py-3 text-red-400 hover:text-red-300 hover:bg-red-500/10 font-bold rounded-md transition duration-200"
+        %>
+      <% else %>
+        <div></div>
+      <% end %>
       <%= f.submit "記事を保存", class: "px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-bold rounded-lg transition duration-150 cursor-pointer shadow-lg" %>
     </div>
   <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,6 +39,9 @@ ja:
     update:
       success: 技術記事を更新しました
       failure: 技術記事の保存に失敗しました
+    destroy:
+      success: 記事を削除しました
+      failure: 記事の削除に失敗しました
   views:
     pagination:
       previous: <

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
 
   resources :daily_reports
-  resources :articles, only: %i[index show new create edit update]
+  resources :articles, only: %i[index show new create edit update destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要

技術記事の削除機能を実装しました。

## 関連 Issue

Closes #57

## 対応内容

- 記事削除機能の実装
  - `ArticlesController#destroy` アクションを追加
  - 編集フォームに削除ボタンを追加（既存の記事のみ表示）
  - ルーティングに `destroy` を追加
- エラーハンドリング
  - `destroy` メソッドを使用し、失敗時はエラーメッセージを表示
  - 早期リターンでシンプルに記述
- 権限チェック
  - `current_user.articles.find` により自分の記事のみ削除可能
  - 他人の記事を削除しようとすると404エラー
- リクエストスペックの追加
  - 自分の記事の削除成功ケース
  - 他人の記事の削除失敗ケース（404）
  - 未ログイン時のリダイレクトケース
- 国際化対応
  - 成功・失敗メッセージを `ja.yml` に追加

## スクリーンショット・画面キャプチャ

削除ボタンは編集ページに表示されます：
- 新規作成時：削除ボタンなし
- 編集時：削除ボタン表示（確認ダイアログ付き）

<img width="1118" height="722" alt="スクリーンショット 2025-12-18 18 33 32" src="https://github.com/user-attachments/assets/7daed36e-f1a1-4d00-9ddd-fb87ee941108" />

<img width="1427" height="722" alt="スクリーンショット 2025-12-18 18 34 20" src="https://github.com/user-attachments/assets/731ebb7b-3797-48ca-8310-63e3bba7b51b" />


## 動作確認

- [x] 自分の記事を削除できること
- [x] 削除時に確認ダイアログが表示されること
- [x] 削除後、記事一覧ページにリダイレクトされること
- [x] 成功メッセージが表示されること
- [x] 他人の記事は削除できないこと（404エラー）
- [x] 未ログイン時はルートページにリダイレクトされること
- [x] リクエストスペックがすべて通過すること

## 備考

- `destroy!` ではなく `destroy` を使用し、失敗時のエラーハンドリングを実装
- セキュリティ：`current_user.articles.find` により所有者チェックを実施
- UI：削除ボタンは赤色で目立つデザインに

