### PR TITLE
fix: ログイン後のリダイレクト先をカレンダーページに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,8 @@ class ApplicationController < ActionController::Base
 
     redirect_to root_path and return
   end
+
+  def after_sign_in_path_for(_resource)
+    daily_reports_path
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,7 +18,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_persisted_user
-    sign_in_and_redirect @user, event: :authentication
+    sign_in_and_redirect @user, event: :authentication, location: daily_reports_path
     set_flash_message(:notice, :success, kind: 'Github') if is_navigational_format?
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,7 +18,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_persisted_user
-    sign_in_and_redirect @user, event: :authentication, location: daily_reports_path
+    sign_in_and_redirect @user, event: :authentication
     set_flash_message(:notice, :success, kind: 'Github') if is_navigational_format?
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -9,6 +9,6 @@ class Users::SessionsController < Devise::SessionsController
 
     sign_in user
 
-    redirect_to root_path, notice: t('devise.sessions.guest.sign_in')
+    redirect_to daily_reports_path, notice: t('devise.sessions.guest.sign_in')
   end
 end

--- a/spec/requests/oauth_spec.rb
+++ b/spec/requests/oauth_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'OAuth Login', type: :request do
         expect(User.last.nickname).to eq 'oauth_test_user'
       end
 
-      it 'トップページへリダイレクトすること' do
-        expect(response).to redirect_to(root_path)
+      it 'カレンダーページへリダイレクトすること' do
+        expect(response).to redirect_to(daily_reports_path)
       end
 
       it '認証成功のフラッシュメッセージが表示されること' do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe 'Sessions', type: :request do
 
   describe 'ゲストログイン' do
     context 'ユーザーが未登録の場合' do
-      it 'ゲストログインが成功し、フラッシュメッセージが表示されること' do
+      it 'ゲストログインが成功し、カレンダーページにリダイレクトされること' do
         expect { post users_guest_sign_in_path }.to change(User, :count).by(1)
+        expect(response).to redirect_to(daily_reports_path)
         follow_redirect!
         expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
         expect(User.last.email).to eq 'guest@example.com'
@@ -52,6 +53,7 @@ RSpec.describe 'Sessions', type: :request do
         initial_count = User.count
         post users_guest_sign_in_path
         expect(User.count).to eq initial_count
+        expect(response).to redirect_to(daily_reports_path)
         follow_redirect!
 
         expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe 'Sessions', type: :request do
         expect(response).to redirect_to(daily_reports_path)
         follow_redirect!
         expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
-        expect(User.last.email).to eq 'guest@example.com'
-        expect(User.last.nickname).to eq 'ゲスト'
+        expect(User.last).to have_attributes(email: 'guest@example.com', nickname: 'ゲスト')
       end
     end
 
@@ -50,12 +49,9 @@ RSpec.describe 'Sessions', type: :request do
       end
 
       it '新規ユーザーを作成せず、既存のユーザーでログインすること' do
-        initial_count = User.count
-        post users_guest_sign_in_path
-        expect(User.count).to eq initial_count
+        expect { post users_guest_sign_in_path }.not_to change(User, :count)
         expect(response).to redirect_to(daily_reports_path)
         follow_redirect!
-
         expect(response.body).to include(I18n.t('devise.sessions.guest.sign_in'))
       end
     end


### PR DESCRIPTION
## 概要
ゲストログインとGitHubログイン後のリダイレクト先をトップページからカレンダーページに変更しました。

## 変更内容
- ゲストログイン後のリダイレクト先を `daily_reports_path` に変更
- GitHubログイン成功後のリダイレクト先を `daily_reports_path` に変更
- テストの追加とリファクタリング

## 関連するコミット
- fix: ゲストログイン・GitHubログイン後のリダイレクト先をカレンダーページに変更
- fix: GitHubログイン後のリダイレクト先がトップページのままだったので、カレンダーページに変更
- refactor: rubocopの警告のため、テストを短くリファクタリング

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-sign-in redirect behavior for both regular and guest users to navigate to the daily reports page instead of the home page.

* **Tests**
  * Updated authentication-related tests to verify the new post-sign-in redirect destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->