### PR TITLE
feat: メモ機能の実装

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -1,0 +1,26 @@
+class MemosController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @pagy, @memos = pagy(current_user.memos.order(created_at: :desc))
+    @memo = Memo.new
+  end
+
+  def create
+    @memo = current_user.memos.build(memo_params)
+
+    if @memo.save
+      redirect_to memos_path, notice: t('.success')
+    else
+      @pagy, @memos = pagy(current_user.memos.order(created_at: :desc))
+      render :index, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def memo_params
+    params.require(:memo).permit(:body)
+  end
+end
+

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -23,4 +23,3 @@ class MemosController < ApplicationController
     params.require(:memo).permit(:body)
   end
 end
-

--- a/app/javascript/controllers/character_counter_controller.js
+++ b/app/javascript/controllers/character_counter_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['input', 'counter', 'remaining']
+  static values = { max: Number }
+
+  connect() {
+    this.updateCounter()
+  }
+
+  updateCounter() {
+    const currentLength = this.inputTarget.value.length
+    const remaining = this.maxValue - currentLength
+
+    this.remainingTarget.textContent = remaining
+
+    if (remaining < 0) {
+      this.counterTarget.classList.add('text-red-500')
+      this.counterTarget.classList.remove('text-gray-500')
+      this.element.setAttribute('maxlength', currentLength)
+    } else {
+      this.counterTarget.classList.remove('text-red-500')
+      this.counterTarget.classList.add('text-gray-500')
+      this.element.setAttribute('maxlength', this.maxValue)
+    }
+  }
+}

--- a/app/javascript/controllers/character_counter_controller.js
+++ b/app/javascript/controllers/character_counter_controller.js
@@ -17,11 +17,9 @@ export default class extends Controller {
     if (remaining < 0) {
       this.counterTarget.classList.add('text-red-500')
       this.counterTarget.classList.remove('text-gray-500')
-      this.element.setAttribute('maxlength', currentLength)
     } else {
       this.counterTarget.classList.remove('text-red-500')
       this.counterTarget.classList.add('text-gray-500')
-      this.element.setAttribute('maxlength', this.maxValue)
     }
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['modal', 'backdrop']
+
+  connect() {
+    this.handleEscape = this.handleEscape.bind(this)
+    this.element.addEventListener('turbo:close-modal', this.close.bind(this))
+  }
+
+  open() {
+    this.modalTarget.classList.remove('hidden')
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', this.handleEscape)
+  }
+
+  close() {
+    this.modalTarget.classList.add('hidden')
+    document.body.style.overflow = ''
+    document.removeEventListener('keydown', this.handleEscape)
+  }
+
+  handleEscape(event) {
+    if (event.key === 'Escape') {
+      this.close()
+    }
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.backdropTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -5,7 +5,13 @@ export default class extends Controller {
 
   connect() {
     this.handleEscape = this.handleEscape.bind(this)
-    this.element.addEventListener('turbo:close-modal', this.close.bind(this))
+    this.closeHandler = this.close.bind(this)
+    this.element.addEventListener('turbo:close-modal', this.closeHandler)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('turbo:close-modal', this.closeHandler)
+    document.removeEventListener('keydown', this.handleEscape)
   }
 
   open() {

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,0 +1,7 @@
+class Memo < ApplicationRecord
+  belongs_to :user
+
+  validates :body, presence: true, length: { maximum: 500 }
+
+  default_scope { order(created_at: :desc) }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :daily_reports, dependent: :destroy
   has_many :articles, dependent: :destroy
+  has_many :memos, dependent: :destroy
 
   def self.from_omniauth(auth)
     return nil if auth.info.email.blank?

--- a/app/views/daily_reports/index.html.erb
+++ b/app/views/daily_reports/index.html.erb
@@ -1,11 +1,15 @@
-<div class="container mx-auto px-4 py-8 max-w-4xl">
-  <div class="flex justify-between items-center">
-    <h1 class="text-3xl font-bold text-white">日報カレンダー</h1>
-    <%= link_to "＋ 日報を書く", new_daily_report_path, class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
-  </div>
+<div class="min-h-screen py-10">
+  <div class="container mx-auto px-4 max-w-4xl">
+    
+    <div class="flex justify-between items-center mb-8">
+      <h1 class="text-3xl font-bold text-white">日報カレンダー</h1>
+      <%= link_to "＋ 日報を書く", new_daily_report_path, class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20" %>
+    </div>
 
-  <div class="rounded-lg shadow-xl mt-6">
-    <%= month_calendar events: @daily_reports, attribute: :date do |day, reports| %>
-    <% end %>
+    <div class="rounded-lg shadow-xl">
+      <%= month_calendar events: @daily_reports, attribute: :date do |day, reports| %>
+      <% end %>
+    </div>
+
   </div>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,12 @@
 
     <nav class="flex items-center gap-4">
       <% if user_signed_in? %>
-        <div class="flex items-center gap-4 pl-4">
+        <div class="flex items-center gap-4">
+          <%= link_to "日報", daily_reports_path, class: "text-sm text-gray-400 hover:text-white transition" %>
+          <%= link_to "記事", articles_path, class: "text-sm text-gray-400 hover:text-white transition" %>
+          <%= link_to "メモ", memos_path, class: "text-sm text-gray-400 hover:text-white transition" %>
+        </div>
+        <div class="flex items-center gap-4 pl-4 border-l border-gray-700">
           <span class="text-sm text-indigo-400 font-medium hidden sm:block">
             <%= current_user.nickname %>
           </span>

--- a/app/views/memos/_form.html.erb
+++ b/app/views/memos/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with model: memo, url: memos_path, data: { turbo: true }, local: false, id: "memo_form", class: "space-y-4" do |f| %>
+  <%= render "shared/error_messages", model: f.object, subject: 'メモの保存' %>
+
+  <div data-controller="character-counter" data-character-counter-max-value="500">
+    <%= f.text_area :body, 
+      rows: 8,
+      maxlength: 500,
+      data: { 
+        character_counter_target: "input",
+        action: "input->character-counter#updateCounter"
+      },
+      class: "w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-gray-900 resize-none" %>
+    <div 
+      data-character-counter-target="counter"
+      class="mt-1 text-sm text-gray-500"
+    >
+      <span data-character-counter-target="remaining">500</span> 文字まで
+    </div>
+  </div>
+
+  <div class="flex justify-end gap-3">
+    <button
+      type="button"
+      data-action="click->modal#close"
+      class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+    >
+      キャンセル
+    </button>
+    <%= f.submit "保存", class: "px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+  </div>
+<% end %>
+

--- a/app/views/memos/_memo.html.erb
+++ b/app/views/memos/_memo.html.erb
@@ -1,6 +1,6 @@
 <article id="memo_<%= memo.id %>" class="bg-white rounded-lg border border-gray-200 shadow-sm py-2 px-6 hover:shadow-md transition-shadow duration-200 mb-4">
   
-  <div class="text-gray-900 text-base whitespace-pre-wrap">
+  <div class="text-gray-900 text-base whitespace-pre-wrap break-words">
     <%= simple_format(h(memo.body)) %>
   </div>
 

--- a/app/views/memos/_memo.html.erb
+++ b/app/views/memos/_memo.html.erb
@@ -1,0 +1,25 @@
+<article id="memo_<%= memo.id %>" class="bg-white rounded-lg border border-gray-200 shadow-sm py-2 px-6 hover:shadow-md transition-shadow duration-200 mb-4">
+  
+  <div class="text-gray-900 text-base whitespace-pre-wrap">
+    <%= simple_format(h(memo.body)) %>
+  </div>
+
+  <div class="flex items-center justify-between pt-4 border-t border-gray-100">
+    
+    <div class="flex items-center">
+      <div class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 text-xs font-bold mr-2">
+        <%= memo.user.nickname&.first&.upcase || '?' %>
+      </div>
+      <span class="text-sm font-medium text-gray-700">
+        @<%= memo.user.nickname %>
+      </span>
+    </div>
+
+    <div class="text-xs text-gray-400">
+      <%= time_ago_in_words(memo.created_at) %>前
+    </div>
+    
+  </div>
+
+</article>
+

--- a/app/views/memos/_modal.html.erb
+++ b/app/views/memos/_modal.html.erb
@@ -1,0 +1,40 @@
+<div
+  id="memo_modal"
+  data-modal-target="modal"
+  class="hidden fixed inset-0 z-50 overflow-y-auto"
+  aria-labelledby="modal-title"
+  role="dialog"
+  aria-modal="true"
+>
+  <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+    <div
+      data-action="click->modal#closeOnBackdrop"
+      data-modal-target="backdrop"
+      class="fixed inset-0 bg-black/50 transition-opacity"
+    ></div>
+
+    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+    <div class="relative z-10 inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+      <div class="bg-white p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-medium text-gray-900" id="modal-title">
+            メモを書く
+          </h3>
+          <button
+            type="button"
+            data-action="click->modal#close"
+            class="text-gray-400 hover:text-gray-500 focus:outline-none"
+          >
+            <span class="sr-only">閉じる</span>
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <%= render "form", memo: memo %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/memos/_modal.html.erb
+++ b/app/views/memos/_modal.html.erb
@@ -15,8 +15,8 @@
 
     <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
 
-    <div class="relative z-10 inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-      <div class="bg-white p-6">
+    <div class="relative z-10 inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-2xl transform transition-all w-full max-w-lg mx-auto sm:my-8 sm:align-middle md:max-w-xl lg:max-w-2xl">
+      <div class="bg-white p-4 sm:p-6">
         <div class="flex items-center justify-between mb-4">
           <h3 class="text-lg font-medium text-gray-900" id="modal-title">
             メモを書く

--- a/app/views/memos/index.html.erb
+++ b/app/views/memos/index.html.erb
@@ -1,0 +1,35 @@
+<div class=" py-10" data-controller="modal">
+  <div class="container mx-auto px-4 max-w-4xl">
+    
+    <div class="flex justify-between items-center mb-8">
+      <h1 class="text-3xl font-bold text-white">メモ</h1>
+      <button 
+        type="button"
+        data-action="click->modal#open"
+        class="inline-block bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md text-sm font-medium transition shadow-lg shadow-indigo-900/20"
+      >
+        ＋ メモを書く
+      </button>
+    </div>
+
+    <%= render "shared/flash_message" %>
+
+    <% if @memos.present? %>
+      <div id="memos" class="space-y-4">
+        <%= render @memos %>
+      </div>
+
+      <div class="mt-10 flex justify-center">
+        <%== @pagy.series_nav(slots: 7) if @pagy.last > 1 %>
+      </div>
+
+    <% else %>
+      <%= render "shared/empty_state", message: "まだメモが投稿されていません" %>
+    <% end %>
+
+  </div>
+
+  <%= render "memos/modal", memo: @memo %>
+</div>
+
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: ユーザー
       daily_report: 日報
       articles: 技術記事
+      memo: メモ
     attributes:
       user:
         email: メールアドレス
@@ -14,6 +15,8 @@ ja:
         title: タイトル
         content: 内容
         status: ステータス
+      memo:
+        body: 本文
     errors:
       models:
         daily_report:
@@ -42,6 +45,10 @@ ja:
     destroy:
       success: 記事を削除しました
       failure: 記事の削除に失敗しました
+  memos:
+    create:
+      success: メモを作成しました
+      failure: メモの保存に失敗しました
   views:
     pagination:
       previous: <

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   resources :daily_reports
   resources :articles, only: %i[index show new create edit update destroy]
+  resources :memos, only: %i[index create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20251222091637_create_memos.rb
+++ b/db/migrate/20251222091637_create_memos.rb
@@ -1,0 +1,12 @@
+class CreateMemos < ActiveRecord::Migration[7.1]
+  def change
+    create_table :memos do |t|
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :memos, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_10_101653) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_22_091637) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_10_101653) do
     t.index ["user_id"], name: "index_daily_reports_on_user_id"
   end
 
+  create_table "memos", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_memos_on_created_at"
+    t.index ["user_id"], name: "index_memos_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -55,4 +64,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_10_101653) do
 
   add_foreign_key "articles", "users"
   add_foreign_key "daily_reports", "users"
+  add_foreign_key "memos", "users"
 end

--- a/spec/factories/memos.rb
+++ b/spec/factories/memos.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :memo do
+    sequence(:body) { |n| "Test memo body #{n}" }
+    association :user
+  end
+end

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Memo, type: :model do
+  describe 'Validation' do
+    let(:user) { create(:user) }
+
+    context '正常系' do
+      it 'すべての属性が正しければ有効であること' do
+        memo = build(:memo, user: user)
+        expect(memo).to be_valid
+      end
+
+      it '本文が500文字以内であれば有効であること' do
+        memo = build(:memo, user: user, body: 'a' * 500)
+        expect(memo).to be_valid
+      end
+    end
+
+    context '異常系' do
+      it { is_expected.to validate_presence_of(:body) }
+      it { is_expected.to validate_length_of(:body).is_at_most(500) }
+    end
+  end
+
+  describe 'Association' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'default_scope' do
+    let(:user) { create(:user) }
+    let!(:old_memo) { create(:memo, user: user, created_at: 1.day.ago) }
+    let!(:new_memo) { create(:memo, user: user, created_at: 1.hour.ago) }
+
+    it '作成日時の降順で取得されること' do
+      expect(Memo.all).to eq([new_memo, old_memo])
+    end
+  end
+end

--- a/spec/models/memo_spec.rb
+++ b/spec/models/memo_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Memo, type: :model do
     let!(:new_memo) { create(:memo, user: user, created_at: 1.hour.ago) }
 
     it '作成日時の降順で取得されること' do
-      expect(Memo.all).to eq([new_memo, old_memo])
+      expect(described_class.all).to eq([new_memo, old_memo])
     end
   end
 end

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -49,19 +49,15 @@ RSpec.describe 'Memos', type: :request do
 
         let!(:oldest_memo) { create(:memo, user: user, body: '2 page memo', created_at: 1.year.ago) }
 
-        context 'パラメータなし（1ページ目）の場合' do
-          it '2ページ目のメモは表示されないこと' do
-            get memos_path
-            expect(response.body).not_to include(oldest_memo.body)
-          end
+        it 'パラメータなし（1ページ目）の場合、2ページ目のメモは表示されないこと' do
+          get memos_path
+          expect(response.body).not_to include(oldest_memo.body)
         end
 
-        context '2ページ目を指定した場合' do
-          it '2ページ目のメモが表示されること' do
-            get memos_path(page: 2)
-            expect(response).to have_http_status(:success)
-            expect(response.body).to include(oldest_memo.body)
-          end
+        it '2ページ目を指定した場合、2ページ目のメモが表示されること' do
+          get memos_path(page: 2)
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(oldest_memo.body)
         end
       end
     end
@@ -130,4 +126,3 @@ RSpec.describe 'Memos', type: :request do
     end
   end
 end
-

--- a/spec/requests/memos_spec.rb
+++ b/spec/requests/memos_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe 'Memos', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  describe 'GET #index' do
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      context 'メモが存在する場合' do
+        let!(:my_memo) { create(:memo, user: user, body: 'My memo') }
+        let!(:other_memo) { create(:memo, user: other_user, body: 'Other user memo') }
+
+        it '正常にレスポンスを返すこと' do
+          get memos_path
+          expect(response).to have_http_status(:success)
+        end
+
+        it '自分のメモのみが表示されること' do
+          get memos_path
+          expect(response.body).to include(my_memo.body)
+          expect(response.body).not_to include(other_memo.body)
+        end
+      end
+
+      context 'メモの並び順' do
+        let!(:old_memo) { create(:memo, user: user, body: 'Old memo', created_at: 1.day.ago) }
+        let!(:new_memo) { create(:memo, user: user, body: 'New memo', created_at: 1.hour.ago) }
+
+        it 'メモが新しい順で表示されること' do
+          get memos_path
+          expect(response.body.index(new_memo.body)).to be < response.body.index(old_memo.body)
+        end
+      end
+
+      context 'メモが存在しない場合' do
+        it '空の状態のメッセージが表示されること' do
+          get memos_path
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('まだメモが投稿されていません')
+        end
+      end
+
+      context 'ページネーション' do
+        before { create_list(:memo, 25, user: user) }
+
+        let!(:oldest_memo) { create(:memo, user: user, body: '2 page memo', created_at: 1.year.ago) }
+
+        context 'パラメータなし（1ページ目）の場合' do
+          it '2ページ目のメモは表示されないこと' do
+            get memos_path
+            expect(response.body).not_to include(oldest_memo.body)
+          end
+        end
+
+        context '2ページ目を指定した場合' do
+          it '2ページ目のメモが表示されること' do
+            get memos_path(page: 2)
+            expect(response).to have_http_status(:success)
+            expect(response.body).to include(oldest_memo.body)
+          end
+        end
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'トップページにリダイレクトされること' do
+        get memos_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_params) { { memo: { body: 'Test memo body' } } }
+    let(:invalid_params) { { memo: { body: '' } } }
+
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      context 'パラメータが有効な場合' do
+        it 'メモがDBに保存され、ユーザーと紐付いていること' do
+          expect do
+            post memos_path, params: valid_params
+          end.to change(Memo, :count).by(1)
+
+          expect(Memo.last.user).to eq(user)
+        end
+
+        it 'メモ一覧ページにリダイレクトすること' do
+          post memos_path, params: valid_params
+          expect(response).to redirect_to(memos_path)
+        end
+      end
+
+      context 'パラメータが無効な場合' do
+        it 'メモがDBに保存されず、フォームが再表示されること' do
+          expect do
+            post memos_path, params: invalid_params
+          end.not_to change(Memo, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
+      context '本文が500文字を超える場合' do
+        let(:over_limit_params) { { memo: { body: 'a' * 501 } } }
+
+        it 'メモがDBに保存されないこと' do
+          expect do
+            post memos_path, params: over_limit_params
+          end.not_to change(Memo, :count)
+
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'メモが保存されず、トップページにリダイレクトされること' do
+        expect do
+          post memos_path, params: valid_params
+        end.not_to change(Memo, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## 概要
ツイッターのような短いメモ（最大500文字）を書く機能を実装しました。モーダルUIで作成し、タイムライン形式で一覧表示します。

## 関連 Issue

## 対応内容

- Memoモデルとマイグレーション追加
- MemosController作成（index, create）
- メモ一覧・作成フォームのビュー追加
- Stimulusコントローラー追加（モーダル、文字数カウンター）
- Turbo Stream対応
- モデルスペック・リクエストスペック追加
- カレンダーページのレイアウトを技術記事・メモ一覧と統一

## スクリーンショット・画面キャプチャ

## 動作確認

- [x] メモ一覧が表示されること
- [x] モーダルでメモを作成できること
- [x] 文字数カウンターが動作すること（500文字制限）
- [x] ページネーションが動作すること
- [x] 自分のメモのみが表示されること
- [x] 未ログイン時はリダイレクトされること
- [x] テストが全て通ること

## 備考

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added memos: create/view personal memos (500 char limit), pagination, empty-state handling, and header navigation
  * Modal-based memo composer with live character counter and accessible controls
  * Model-level validation and user association; DB migration and routes added
  * Japanese translations for memos

* **Style**
  * Improved daily reports layout with enhanced visual structure

* **Tests**
  * Comprehensive model and request tests covering memos behavior and edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->